### PR TITLE
make initFonts.sh run succesfully even when the child dir doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/
+texmf-local/fonts/opentype/
 .vscode/
 .DS_Store

--- a/initFonts.sh
+++ b/initFonts.sh
@@ -1,5 +1,12 @@
-cp "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc" "texmf-local/fonts/opentype/hiragino/HiraginoSansR-W4.ttc"
-cp "/System/Library/Fonts/ヒラギノ丸ゴ ProN W4.ttc" "texmf-local/fonts/opentype/hiragino/HiraginoSans-W6.ttc"
-cp "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc" "texmf-local/fonts/opentype/hiragino/HiraginoSans-W3.ttc"
-cp "/System/Library/Fonts/ヒラギノ明朝 ProN.ttc"    "texmf-local/fonts/opentype/hiragino/HiraginoSerif.ttc"
-cp "/System/Library/Fonts/ヒラギノ角ゴシック W8.ttc" "texmf-local/fonts/opentype/hiragino/HiraginoSans-W8.ttc"
+#!/bin/sh
+set -x
+
+SRCDIR="/System/Library/Fonts/"
+DSTDIR="texmf-local/fonts/opentype/"
+
+mkdir -p texmf-local/fonts/opentype/hiragino
+cp $SRCDIR"ヒラギノ角ゴシック W3.ttc" $DSTDIR"hiragino/HiraginoSansR-W4.ttc"
+cp $SRCDIR"ヒラギノ丸ゴ ProN W4.ttc" $DSTDIR"hiragino/HiraginoSans-W6.ttc"
+cp $SRCDIR"ヒラギノ角ゴシック W6.ttc" $DSTDIR"hiragino/HiraginoSans-W3.ttc"
+cp $SRCDIR"ヒラギノ明朝 ProN.ttc"    $DSTDIR"hiragino/HiraginoSerif.ttc"
+cp $SRCDIR"ヒラギノ角ゴシック W8.ttc" $DSTDIR"hiragino/HiraginoSans-W8.ttc"


### PR DESCRIPTION
initFonts.sh の以下の改善：
- texmf-local/fonts/opentype/hiragino が存在しなくてもコピーエラーにならないように
- 実行中のコマンドを表示するように
- 共通のディレクトリ名を変数に入れる